### PR TITLE
Make the service worker cache the manifest

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // A list of local resources we always want to be cached.
 /*
 const PRECACHE_URLS = [
-    'manifest.json',
+    'pwa/manifest.json',
     'css/article.css',
     'img/bch.png',
     'css/base.css',


### PR DESCRIPTION
This is a result of the cleanup,. the reference here didn't get changed.